### PR TITLE
Accept session param to allow recovering lost session

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ In the main lines:
 - Each message received from the concierge are pushed on a Redis Channel
 - Each Dynos listen to the channel
 - When an event is pushed onto a channel, the dyno looks for its in-memory dictionary and pushes to the websocket client if part of its dictionary.
+
+## Idle in AWS
+
+While the websocket is open between the Pet Parent and the nodeJs server, if no message is send during more than 60s the connection will be dropped. This can be configured on AWS side: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout but to be noted that there are other (infrastructure) parties involved in the dance that might have their own idle timeout values...
+
+The websocket connection upgrade request accepts a session params that will be used as identifier of the pet parent. This way even if the connection drops, idle or the server goes down for a while, the client implementation can recover the session and keep chatting without having to start over.

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 
 const express = require("express");
 const http = require("http");
+const url = require("url");
 const uuid = require("uuid");
 const WebSocket = require("ws");
 
@@ -38,14 +39,15 @@ const server = http.createServer(app);
 const wss = new WebSocket.Server({ clientTracking: false, noServer: true });
 
 server.on("upgrade", function (request, socket, head) {
-  const userId = uuid.v4();
-
   wss.handleUpgrade(request, socket, head, function (ws) {
-    wss.emit("connection", ws, request, userId);
+    wss.emit("connection", ws, request);
   });
 });
 
-wss.on("connection", function (ws, request, userId) {
+wss.on("connection", function (ws, request) {
+  const query = url.parse(request.url, true).query;
+  const userId = query.session || uuid.v4();
+
   map.set(userId, ws);
 
   ws.on("message", async function (message) {


### PR DESCRIPTION
## Why ?
AWS default idle timeout is set to 60s meaning if the client does not push any message during 60s it will get disconnected. When reconnecting, we need a way of matching up its old websocket with the new one so it can continue chatting and not have to start over.

## Changes
- Allow session param to be passed as query parameter (advised to be a uuid to prevent colision with other pet parents :/ )

 